### PR TITLE
fix: fixing color contrast in search modal

### DIFF
--- a/src/client/theme/SearchModal/index.module.css
+++ b/src/client/theme/SearchModal/index.module.css
@@ -22,7 +22,7 @@ html[data-theme="dark"] {
 .searchModalContainer {
   box-shadow: rgba(255, 255, 255, 0.5) 1px 1px 0px 0px inset,
     rgb(85, 90, 100) 0px 3px 8px 0px;
-  background: var(--ifm-color-primary-contrast-background);
+  background: var(--ifm-background-surface-color);
   position: relative;
 
   flex-direction: column;
@@ -152,7 +152,7 @@ html[data-theme="dark"] {
 }
 
 .searchResultsSectionHeader {
-  background: var(--ifm-color-primary-contrast-background);
+  background: var(--ifm-background-surface-color);
   font-size: 0.85em;
   font-weight: 600;
   line-height: 32px;
@@ -167,7 +167,7 @@ html[data-theme="dark"] {
 /* SearchResult Component */
 .searchResult {
   cursor: pointer;
-  background: var(--ifm-background-surface-color);
+  background: var(--ifm-color-primary-contrast-background);
   border-radius: 4px;
   box-shadow: var(--search-local-result-shadow, 0 1px 3px 0 #d4d9e1);
   margin-bottom: 4px;


### PR DESCRIPTION
## Before

<img width="712" alt="Screen Shot 2022-02-23 at 11 02 30 AM" src="https://user-images.githubusercontent.com/702906/155389299-528531db-1cdb-4a82-9a46-8d93e9ef2fec.png">

## After

<img width="719" alt="Screen Shot 2022-02-23 at 10 59 42 AM" src="https://user-images.githubusercontent.com/702906/155389320-85cf7ba3-d230-4953-8e9d-63d9438ab35a.png">
